### PR TITLE
fixes for handling "Origin" Header

### DIFF
--- a/transport_xhrmultipart.go
+++ b/transport_xhrmultipart.go
@@ -64,7 +64,7 @@ func (s *xhrMultipartSocket) accept(w http.ResponseWriter, req *http.Request, pr
 		buf.WriteString("HTTP/1.0 200 OK\r\n")
 		buf.WriteString("Content-Type: multipart/x-mixed-replace; boundary=\"socketio\"\r\n")
 		buf.WriteString("Connection: keep-alive\r\n")
-		if origin, ok := req.Header["Origin"]; ok {
+		if origin := req.Header.Get("Origin"); origin != "" {
 			fmt.Fprintf(buf,
 				"Access-Control-Allow-Origin: %s\r\nAccess-Control-Allow-Credentials: true\r\n",
 				origin)
@@ -91,7 +91,6 @@ func (s *xhrMultipartSocket) Read(p []byte) (n int, err os.Error) {
 
 	return s.rwc.Read(p)
 }
-
 
 // Write sends a single multipart message to the wire.
 func (s *xhrMultipartSocket) Write(p []byte) (n int, err os.Error) {

--- a/transport_xhrpolling.go
+++ b/transport_xhrpolling.go
@@ -88,7 +88,7 @@ func (s *xhrPollingSocket) Write(p []byte) (int, os.Error) {
 	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
 	fmt.Fprintf(buf, "Content-Length: %d\r\n", len(p))
 
-	if origin, ok := s.req.Header["Origin"]; ok {
+	if origin := s.req.Header.Get("Origin"); origin != "" {
 		fmt.Fprintf(buf, "Access-Control-Allow-Origin: %s\r\n", origin)
 		buf.WriteString("Access-Control-Allow-Credentials: true\r\n")
 	}


### PR DESCRIPTION
- Header["Origin"] was returning a slice, which was directly formatted into the
  response Header and would fail to match the original origin. Using
  Header.Get("Origin") now
